### PR TITLE
fix: make event management card-footer readable in dark-mode

### DIFF
--- a/packages/surfcamp-events/Resources/Private/Templates/Backend/EventGenerator/Index.html
+++ b/packages/surfcamp-events/Resources/Private/Templates/Backend/EventGenerator/Index.html
@@ -99,7 +99,7 @@
                                             </f:if>
                                         </f:comment>
                                     </div>
-                                    <div class="card-footer flex-grow-1" style="background-color: #dddddd;">
+                                    <div class="card-footer flex-grow-1" style="background-color: var(--typo3-surface-container-high)">
                                         <div class="actions d-block w-full">
                                             <div class="row">
                                                 <div class="col-6 d-flex flex-column align-items-start justify-content-start gap-2">


### PR DESCRIPTION
Use a CSS variable that is initialized with
a light-dark color function and allows to
create contrast in both modes.